### PR TITLE
clarity

### DIFF
--- a/docs/api/search/pif/query/PifQuery.md
+++ b/docs/api/search/pif/query/PifQuery.md
@@ -6,11 +6,13 @@ A PifQuery object contains all information for a single query.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
-`from` | Integer | 0 | Index of the first hit that should be returned. Used for pagination.
+`fromIndex` | Integer | 0 | Index of the first hit that should be returned. Used for pagination.
 `size` | Integer | 100 | Total number of hits that should be returned.  Used for pagination. Maximum value of 100.
 `returnSystem` | Boolean | True | True to return the PIF objects that matched. False omits the PIF objects and returns only their IDs.
 `addLatex` | Boolean | False | True to inject Latex formatting into the results where possible. This only applies to a small subset of the fields in the results.
-`scoreRelevance` | Boolean | False | True to turn on relevancy so that the _best_ matches appear first.
+`scoreRelevance` | Boolean | False | True to turn on relevancy so that the \*_best_ matches appear first.
 `system` | Array of [`SystemQuery`](!api/search/pif/query/core/SystemQuery) objects | | List of queries to execute at the System level.
 `includeDatasets` | Array of integers | | Filter on a subset of datasets by their unique ID.
 `excludeDatasets` | Array of integers | | Filter out a subset of datasets by their unique ID.
+
+\* _best_ is a subjective measure, but is incorporated into Citrination using a relevancy-based metric. A number of factors are used in the relevancy score including the number of terms that matched, quality of match, and frequency of match.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -25,6 +25,8 @@ The previous python client used the following fields to define a search:
 
 These fields map to a the new [`PifQuery`](!api/search/pif/query/PifQuery) object in the following way. Any fields that are not defined can be omitted.
 
+** Note the differences between old keywords and new keywords. Especially that `from_record` is now `from_index` and `per_page` is now `size`. **
+
 ```Python
 from citrination-client import *
 query = PifQuery(


### PR DESCRIPTION
@maxhutch This adds clarity to the migration guide around names of terms that have changed.